### PR TITLE
Implement NFT Minting with Dual-Chain Architecture

### DIFF
--- a/mcp-server/src/abi/nftMinter.ts
+++ b/mcp-server/src/abi/nftMinter.ts
@@ -381,19 +381,18 @@ export const abi = [
         type: 'address',
       },
       {
+        internalType: 'uint256',
+        name: 'tokenId',
+        type: 'uint256',
+      },
+      {
         internalType: 'string',
-        name: 'tokenMetadataURI',
+        name: 'uri',
         type: 'string',
       },
     ],
-    name: 'mintNFT',
-    outputs: [
-      {
-        internalType: 'uint256',
-        name: '',
-        type: 'uint256',
-      },
-    ],
+    name: 'safeMintWithURI',
+    outputs: [],
     stateMutability: 'nonpayable',
     type: 'function',
   },

--- a/mcp-server/src/addresses.ts
+++ b/mcp-server/src/addresses.ts
@@ -11,7 +11,7 @@ export const addresses: Record<string, Record<number, Address>> = {
     [shapeSepolia.id]: '0xaF94F7b7Dd601967E3ebdba052F5Ed6d215220b3',
   },
   nftMinter: {
-    [shapeSepolia.id]: '0xf8C93f671e24A60f4c11612b2DFAC3DD83F41340',
-    [shape.id]: zeroAddress, // Replace with actual address when deployed to mainnet
+    [shapeSepolia.id]: '0x9FdB107c9AAE301F021e1F34BEB8Ca6F2324de85', // KatachiGen contract on testnet
+    [shape.id]: '0x9fba90186403d1c5e3e1971536862cf4ebb0f766', // KatachiGen contract on mainnet
   },
 };

--- a/mcp-server/src/tools/nft/prepare-mint-svg-nft.ts
+++ b/mcp-server/src/tools/nft/prepare-mint-svg-nft.ts
@@ -71,12 +71,15 @@ export default async function prepareMintSVGNFT(params: InferSchema<typeof schem
 
     const tokenURI = `data:application/json;base64,${Buffer.from(JSON.stringify(metadata)).toString('base64')}`;
 
+    // Generate a random token ID (in production, this should be managed properly)
+    const tokenId = Date.now() + Math.floor(Math.random() * 1000);
+
     const transactionData = {
       to: contractAddress,
       data: encodeFunctionData({
         abi: nftMinterAbi,
-        functionName: 'mintNFT',
-        args: [recipientAddress, tokenURI],
+        functionName: 'safeMintWithURI',
+        args: [recipientAddress, BigInt(tokenId), tokenURI],
       }),
       value: '0x0', // No ETH value needed
     };
@@ -86,11 +89,12 @@ export default async function prepareMintSVGNFT(params: InferSchema<typeof schem
       transaction: transactionData,
       metadata: {
         contractAddress,
-        functionName: 'mintNFT',
+        functionName: 'safeMintWithURI',
         recipientAddress,
+        tokenId: tokenId.toString(),
         tokenURI,
         nftMetadata: metadata,
-        estimatedGas: '100000', // TODO: Get actual gas estimate to prevent failed transactions
+        estimatedGas: '150000', // Increased for safeMintWithURI
         chainId,
         explorerUrl: `https://sepolia.shapescan.xyz/address/${contractAddress}`,
       },

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -115,6 +115,7 @@ export type PrepareMintSVGNFTOutput = {
     contractAddress: Address;
     functionName: string;
     recipientAddress: Address;
+    tokenId: string;
     tokenURI: string;
     nftMetadata: Record<string, unknown>;
     estimatedGas: string;

--- a/public-site/.env-example
+++ b/public-site/.env-example
@@ -1,11 +1,15 @@
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=
 NEXT_PUBLIC_ALCHEMY_KEY=
 
-# Shape Testnet
-NEXT_PUBLIC_CHAIN_ID=11011
+# Shape Network Configuration
+# Reading chain (for NFT data) - use mainnet for real data
+NEXT_PUBLIC_READ_CHAIN_ID=360
+# Minting chain (for NFT contract) - use testnet for safe testing
+NEXT_PUBLIC_MINT_CHAIN_ID=11011
 
-# Shape Mainnet
-# NEXT_PUBLIC_CHAIN_ID=360
+# Contract Addresses
+NEXT_PUBLIC_KATACHI_CONTRACT_TESTNET=0x9FdB107c9AAE301F021e1F34BEB8Ca6F2324de85
+# NEXT_PUBLIC_KATACHI_CONTRACT_MAINNET=
 
 # MCP Server URL for sentiment interpretation (local dev or production)
 MCP_SERVER_URL=http://localhost:3002/mcp #LOCAL DEV

--- a/public-site/README-builderKit.md
+++ b/public-site/README-builderKit.md
@@ -48,7 +48,9 @@ See deployed website: [builder-kit.vercel.app](https://builder-kit.vercel.app/)
 
    - `NEXT_PUBLIC_ALCHEMY_KEY`: Get from [Alchemy](https://alchemy.com)
    - `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID`: Get from [WalletConnect](https://cloud.walletconnect.com)
-   - `NEXT_PUBLIC_CHAIN_ID`: Use `11011` for Shape Sepolia or `360` for Shape Mainnet
+   - `NEXT_PUBLIC_READ_CHAIN_ID`: Use `360` for Shape Mainnet (for reading NFT data)
+   - `NEXT_PUBLIC_MINT_CHAIN_ID`: Use `11011` for Shape Sepolia (for minting NFTs)
+   - `NEXT_PUBLIC_KATACHI_CONTRACT_TESTNET`: Contract address on testnet
 
 4. **Start development server**
 

--- a/public-site/README.md
+++ b/public-site/README.md
@@ -38,7 +38,13 @@ Create a `.env.local` file in the project root:
 
 ```bash
 # Shape Network Configuration
-NEXT_PUBLIC_CHAIN_ID=360
+# Reading chain (for NFT data) - use mainnet for real data
+NEXT_PUBLIC_READ_CHAIN_ID=360
+# Minting chain (for NFT contract) - use testnet for safe testing
+NEXT_PUBLIC_MINT_CHAIN_ID=11011
+
+# Contract Addresses
+NEXT_PUBLIC_KATACHI_CONTRACT_TESTNET=0x9FdB107c9AAE301F021e1F34BEB8Ca6F2324de85
 
 # Alchemy API Key (get from https://www.alchemy.com/)
 NEXT_PUBLIC_ALCHEMY_KEY=your_alchemy_api_key

--- a/public-site/app/api/mint-origami/route.ts
+++ b/public-site/app/api/mint-origami/route.ts
@@ -1,0 +1,138 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { isAddress } from 'viem';
+import { chainConfig } from '@/lib/chains';
+import { config } from '@/lib/config';
+import { shape } from 'viem/chains';
+
+type MintOrigamiRequest = {
+  recipientAddress: string;
+  svgContent: string;
+  name: string;
+  description?: string;
+};
+
+
+export async function POST(request: NextRequest) {
+  try {
+    const body: MintOrigamiRequest = await request.json();
+    const { recipientAddress, svgContent, name, description } = body;
+
+    if (!recipientAddress || !isAddress(recipientAddress)) {
+      return NextResponse.json(
+        { error: 'Invalid recipient address' },
+        { status: 400 }
+      );
+    }
+
+    if (!svgContent || !svgContent.trim()) {
+      return NextResponse.json(
+        { error: 'SVG content is required' },
+        { status: 400 }
+      );
+    }
+
+    if (!name || !name.trim()) {
+      return NextResponse.json(
+        { error: 'NFT name is required' },
+        { status: 400 }
+      );
+    }
+
+    // Safety check: prevent accidental mainnet minting
+    if (config.mintChainId === shape.id && !config.allowMainnetMinting) {
+      return NextResponse.json(
+        { 
+          error: 'Mainnet minting is disabled for safety',
+          details: 'Set NEXT_PUBLIC_ALLOW_MAINNET_MINTING=true to enable mainnet minting'
+        },
+        { status: 403 }
+      );
+    }
+
+    const mcpServerUrl = process.env.MCP_SERVER_URL;
+    if (!mcpServerUrl) {
+      return NextResponse.json(
+        { error: 'MCP server not configured' },
+        { status: 500 }
+      );
+    }
+
+    const mcpRequest = {
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: {
+        name: 'prepareMintSVGNFT',
+        arguments: {
+          recipientAddress,
+          svgContent,
+          name,
+          description: description || `Katachi Gen origami pattern - ${name}`,
+        },
+      },
+      id: Date.now(),
+    };
+
+    const response = await fetch(mcpServerUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+      body: JSON.stringify(mcpRequest),
+    });
+
+    if (!response.ok) {
+      throw new Error(`MCP server responded with status: ${response.status}`);
+    }
+
+    const mcpResponse = await response.json();
+
+    // Handle JSON-RPC error response
+    if (mcpResponse.error) {
+      return NextResponse.json(
+        { 
+          error: 'MCP server error',
+          details: mcpResponse.error.message || 'Unknown error from MCP server'
+        },
+        { status: 500 }
+      );
+    }
+
+    // Extract result from JSON-RPC response
+    let result = mcpResponse.result;
+    if (mcpResponse.result && mcpResponse.result.content && mcpResponse.result.content[0] && mcpResponse.result.content[0].text) {
+      try {
+        result = JSON.parse(mcpResponse.result.content[0].text);
+      } catch (e) {
+        console.warn('Could not parse MCP response as JSON:', e);
+        result = mcpResponse.result;
+      }
+    }
+
+    // Check if the parsed result indicates an error
+    if (result.error) {
+      return NextResponse.json(
+        { 
+          error: 'MCP server error',
+          details: result.message || 'Unknown error from MCP server'
+        },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      mintData: result,
+    });
+
+  } catch (error) {
+    console.error('Error in mint-origami API:', error);
+    return NextResponse.json(
+      { 
+        error: 'Internal server error',
+        details: error instanceof Error ? error.message : 'Unknown error'
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/public-site/components/providers.tsx
+++ b/public-site/components/providers.tsx
@@ -5,6 +5,7 @@ import { wagmiConfig } from '@/lib/web3';
 import { darkTheme, lightTheme, RainbowKitProvider } from '@rainbow-me/rainbowkit';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from 'next-themes';
+import { Toaster } from '@/components/ui/sonner';
 import { ReactNode } from 'react';
 import { shape, shapeSepolia } from 'viem/chains';
 import { WagmiProvider } from 'wagmi';
@@ -21,9 +22,10 @@ export const Providers = ({ children }: { children: ReactNode }) => {
               lightMode: lightTheme(),
               darkMode: darkTheme(),
             }}
-            initialChain={config.chainId === shape.id ? shape : shapeSepolia}
+            initialChain={config.mintChainId === shape.id ? shape : shapeSepolia}
           >
             {children}
+            <Toaster />
           </RainbowKitProvider>
         </QueryClientProvider>
       </WagmiProvider>

--- a/public-site/hooks/use-balance.ts
+++ b/public-site/hooks/use-balance.ts
@@ -12,7 +12,7 @@ export function useWalletBalance() {
     error,
   } = useBalance({
     address,
-    chainId: config.chainId,
+    chainId: config.mintChainId, // Use mint chain for balance (where users need funds to mint)
     query: {
       enabled: isConnected && !!address,
       refetchInterval: 30000, // Refetch every 30 seconds

--- a/public-site/hooks/useMintOrigami.ts
+++ b/public-site/hooks/useMintOrigami.ts
@@ -1,0 +1,172 @@
+import { useState } from 'react';
+import { useAccount, useWriteContract, useWaitForTransactionReceipt } from 'wagmi';
+import { parseAbi } from 'viem';
+import { toast } from 'sonner';
+
+type MintState = 'idle' | 'preparing' | 'pending' | 'confirming' | 'success' | 'error';
+
+type MintOrigamiData = {
+  recipientAddress: string;
+  svgContent: string;
+  name: string;
+  description?: string;
+};
+
+type PreparedMintData = {
+  success: boolean;
+  mintData: {
+    transaction: {
+      to: string;
+      data: string;
+      value: string;
+    };
+    metadata: {
+      contractAddress: string;
+      functionName: string;
+      recipientAddress: string;
+      tokenURI: string;
+      nftMetadata: Record<string, unknown>;
+      estimatedGas: string;
+      chainId: number;
+      explorerUrl: string;
+    };
+    instructions: {
+      nextSteps: string[];
+    };
+  };
+};
+
+// ABI for the safeMintWithURI function
+const mintNFTAbi = parseAbi([
+  'function safeMintWithURI(address to, uint256 tokenId, string memory uri) public'
+]);
+
+export function useMintOrigami() {
+  const [state, setState] = useState<MintState>('idle');
+  const [preparedData, setPreparedData] = useState<PreparedMintData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  
+  const { address } = useAccount();
+  
+  const { 
+    writeContract, 
+    data: transactionHash, 
+    isPending: isTransactionPending,
+    error: writeError 
+  } = useWriteContract();
+  
+  const { 
+    isLoading: isConfirming, 
+    isSuccess: isConfirmed,
+    error: confirmError
+  } = useWaitForTransactionReceipt({
+    hash: transactionHash,
+  });
+
+  const prepareMint = async (mintData: MintOrigamiData) => {
+    try {
+      setState('preparing');
+      setError(null);
+      
+      const response = await fetch('/api/mint-origami', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(mintData),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.details || errorData.error || 'Failed to prepare mint');
+      }
+
+      const result: PreparedMintData = await response.json();
+      setPreparedData(result);
+      setState('idle');
+      
+      return result;
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to prepare mint';
+      setError(errorMessage);
+      setState('error');
+      toast.error(errorMessage);
+      throw err;
+    }
+  };
+
+  const executeMint = async () => {
+    if (!preparedData || !address) {
+      throw new Error('No prepared mint data or wallet not connected');
+    }
+
+    try {
+      setState('pending');
+      setError(null);
+
+      const { transaction, metadata } = preparedData.mintData;
+      
+      // Use the prepared transaction data with safeMintWithURI
+      writeContract({
+        address: transaction.to as `0x${string}`,
+        abi: mintNFTAbi,
+        functionName: 'safeMintWithURI',
+        args: [
+          metadata.recipientAddress as `0x${string}`, 
+          BigInt(metadata.tokenId), 
+          metadata.tokenURI
+        ],
+      });
+
+      toast.success('Transaction submitted! Please wait for confirmation...');
+      
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to execute mint';
+      setError(errorMessage);
+      setState('error');
+      toast.error(errorMessage);
+      throw err;
+    }
+  };
+
+  // Update state based on transaction status
+  if (isTransactionPending && state !== 'pending') {
+    setState('pending');
+  }
+
+  if (isConfirming && state !== 'confirming') {
+    setState('confirming');
+    toast.success('Transaction confirmed! Minting your NFT...');
+  }
+
+  if (isConfirmed && state !== 'success') {
+    setState('success');
+    toast.success('NFT minted successfully! 🎉');
+  }
+
+  if ((writeError || confirmError) && state !== 'error') {
+    const errorMessage = writeError?.message || confirmError?.message || 'Transaction failed';
+    setError(errorMessage);
+    setState('error');
+    toast.error(errorMessage);
+  }
+
+  const reset = () => {
+    setState('idle');
+    setPreparedData(null);
+    setError(null);
+  };
+
+  return {
+    state,
+    error,
+    preparedData,
+    transactionHash,
+    isLoading: state === 'preparing' || isTransactionPending || isConfirming,
+    isSuccess: state === 'success',
+    isError: state === 'error',
+    prepareMint,
+    executeMint,
+    reset,
+  };
+}

--- a/public-site/lib/chains.ts
+++ b/public-site/lib/chains.ts
@@ -1,0 +1,55 @@
+import { config } from './config';
+import { shape, shapeSepolia } from 'viem/chains';
+import { Chain } from 'viem';
+
+// Get the chain object for reading NFT data (mainnet for real data)
+export function getReadChain(): Chain {
+  return config.readChainId === shape.id ? shape : shapeSepolia;
+}
+
+// Get the chain object for minting (testnet for safe testing)
+export function getMintChain(): Chain {
+  return config.mintChainId === shape.id ? shape : shapeSepolia;
+}
+
+// Get the appropriate Katachi contract address based on chain with safety checks
+export function getKatachiContractAddress(chainId: number): string {
+  if (chainId === shape.id) {
+    // Safety check: prevent accidental mainnet minting
+    if (!config.allowMainnetMinting) {
+      throw new Error('Mainnet minting is disabled. Set NEXT_PUBLIC_ALLOW_MAINNET_MINTING=true to enable.');
+    }
+    return config.katachiContractMainnet || '';
+  } else if (chainId === shapeSepolia.id) {
+    return config.katachiContractTestnet || '';
+  }
+  return '';
+}
+
+// Get the contract address for the current mint chain with safety validation
+export function getMintContractAddress(): string {
+  // Additional safety check
+  if (config.mintChainId === shape.id && !config.allowMainnetMinting) {
+    console.warn('🚨 Mainnet minting is disabled for safety. Using testnet instead.');
+    return config.katachiContractTestnet;
+  }
+  
+  return getKatachiContractAddress(config.mintChainId);
+}
+
+// Chain configuration details
+export const chainConfig = {
+  read: {
+    chainId: config.readChainId,
+    chain: getReadChain(),
+    name: config.readChainId === shape.id ? 'Shape Mainnet' : 'Shape Sepolia',
+    explorer: config.readChainId === shape.id ? 'https://shapescan.xyz' : 'https://sepolia.shapescan.xyz',
+  },
+  mint: {
+    chainId: config.mintChainId,
+    chain: getMintChain(),
+    name: config.mintChainId === shape.id ? 'Shape Mainnet' : 'Shape Sepolia', 
+    explorer: config.mintChainId === shape.id ? 'https://shapescan.xyz' : 'https://sepolia.shapescan.xyz',
+    contractAddress: getMintContractAddress(),
+  }
+} as const;

--- a/public-site/lib/clients.ts
+++ b/public-site/lib/clients.ts
@@ -4,13 +4,15 @@ import { Alchemy, Network } from 'alchemy-sdk';
 import { createPublicClient, http } from 'viem';
 import { shape, shapeSepolia } from 'viem/chains';
 
+// Use read chain for Alchemy client (for fetching NFT data)
 export const alchemy = new Alchemy({
   apiKey: config.alchemyKey,
-  network: config.chainId === shape.id ? Network.SHAPE_MAINNET : Network.SHAPE_SEPOLIA,
+  network: config.readChainId === shape.id ? Network.SHAPE_MAINNET : Network.SHAPE_SEPOLIA,
 });
 
+// RPC client for reading blockchain data
 export function rpcClient() {
-  const chainId = config.chainId;
+  const chainId = config.readChainId;
   const chain = chainId === shape.id ? shape : shapeSepolia;
   const rootUrl = chainId === shape.id ? 'shape-mainnet' : 'shape-sepolia';
 

--- a/public-site/lib/config.ts
+++ b/public-site/lib/config.ts
@@ -1,5 +1,16 @@
 export const config = {
-  chainId: Number(process.env.NEXT_PUBLIC_CHAIN_ID),
+  // Separate chain IDs for reading vs minting
+  readChainId: Number(process.env.NEXT_PUBLIC_READ_CHAIN_ID),
+  mintChainId: Number(process.env.NEXT_PUBLIC_MINT_CHAIN_ID),
+  
+  // Safety settings
+  allowMainnetMinting: process.env.NEXT_PUBLIC_ALLOW_MAINNET_MINTING === 'true',
+  
+  // Contract addresses
+  katachiContractTestnet: process.env.NEXT_PUBLIC_KATACHI_CONTRACT_TESTNET as string,
+  katachiContractMainnet: process.env.NEXT_PUBLIC_KATACHI_CONTRACT_MAINNET as string,
+  
+  // API keys
   alchemyKey: process.env.NEXT_PUBLIC_ALCHEMY_KEY as string,
   walletConnectProjectId: process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID as string,
 } as const;

--- a/public-site/utils/generatePlaceholderSVG.ts
+++ b/public-site/utils/generatePlaceholderSVG.ts
@@ -1,0 +1,210 @@
+// Placeholder SVG generator for testing minting functionality
+// TODO: Replace with actual origami pattern generation later
+
+type PatternData = {
+  nftCount: number;
+  collections: number;
+  stackRank?: number;
+  walletAddress: string;
+};
+
+type GeneratedPattern = {
+  svgContent: string;
+  metadata: {
+    name: string;
+    description: string;
+    patternType: string;
+    complexity: 'Basic' | 'Medium' | 'High';
+    foldLines: number;
+    colors: string[];
+    traits: Array<{
+      trait_type: string;
+      value: string | number;
+    }>;
+  };
+};
+
+const ORIGAMI_PATTERNS = [
+  'Kabuto (Samurai Helmet)',
+  'Tsuru (Crane)',
+  'Sakura (Cherry Blossom)',
+  'Koi (Carp)',
+  'Shuriken (Throwing Star)',
+  'Lotus Flower',
+  'Mountain Peak',
+  'Wave Pattern'
+];
+
+const BASE_COLORS = [
+  '#4F46E5', // Indigo
+  '#06B6D4', // Cyan  
+  '#10B981', // Emerald
+  '#F59E0B', // Amber
+  '#EF4444', // Red
+  '#8B5CF6', // Violet
+  '#EC4899', // Pink
+  '#84CC16', // Lime
+];
+
+function generateRandomOrigamiSVG(colors: string[], complexity: number): string {
+  const size = 400;
+  const centerX = size / 2;
+  const centerY = size / 2;
+  
+  // Create fold lines based on complexity
+  const foldCount = Math.min(complexity * 2 + 8, 24);
+  const folds: string[] = [];
+  
+  // Generate radial fold lines (typical of origami)
+  for (let i = 0; i < foldCount; i++) {
+    const angle = (i / foldCount) * 2 * Math.PI;
+    const innerRadius = 40 + Math.random() * 60;
+    const outerRadius = 150 + Math.random() * 100;
+    
+    const x1 = centerX + Math.cos(angle) * innerRadius;
+    const y1 = centerY + Math.sin(angle) * innerRadius;
+    const x2 = centerX + Math.cos(angle) * outerRadius;
+    const y2 = centerY + Math.sin(angle) * outerRadius;
+    
+    folds.push(`<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="${colors[i % colors.length]}" stroke-width="2" opacity="0.7" stroke-dasharray="5,5"/>`);
+  }
+  
+  // Generate geometric shapes representing folded sections
+  const shapes: string[] = [];
+  const shapeCount = 4 + Math.floor(complexity / 3);
+  
+  for (let i = 0; i < shapeCount; i++) {
+    const angle = (i / shapeCount) * 2 * Math.PI;
+    const radius = 80 + Math.random() * 60;
+    const x = centerX + Math.cos(angle) * radius;
+    const y = centerY + Math.sin(angle) * radius;
+    const size = 20 + Math.random() * 30;
+    const color = colors[i % colors.length];
+    
+    if (i % 3 === 0) {
+      // Triangle
+      const points = [
+        [x, y - size],
+        [x - size * 0.866, y + size * 0.5],
+        [x + size * 0.866, y + size * 0.5]
+      ].map(p => p.join(',')).join(' ');
+      
+      shapes.push(`<polygon points="${points}" fill="${color}" opacity="0.8"/>`);
+    } else if (i % 3 === 1) {
+      // Rectangle
+      shapes.push(`<rect x="${x - size/2}" y="${y - size/2}" width="${size}" height="${size}" fill="${color}" opacity="0.6" transform="rotate(${angle * 180 / Math.PI} ${x} ${y})"/>`);
+    } else {
+      // Circle
+      shapes.push(`<circle cx="${x}" cy="${y}" r="${size/2}" fill="${color}" opacity="0.7"/>`);
+    }
+  }
+  
+  return `<svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#f8fafc;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#e2e8f0;stop-opacity:1" />
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="2" dy="2" stdDeviation="3" flood-color="#00000020"/>
+    </filter>
+  </defs>
+  
+  <!-- Background -->
+  <rect width="100%" height="100%" fill="url(#bg)"/>
+  
+  <!-- Border -->
+  <rect x="10" y="10" width="${size-20}" height="${size-20}" fill="none" stroke="#cbd5e1" stroke-width="2" rx="8"/>
+  
+  <!-- Origami pattern -->
+  <g filter="url(#shadow)">
+    ${shapes.join('\n    ')}
+    ${folds.join('\n    ')}
+  </g>
+  
+  <!-- Center point -->
+  <circle cx="${centerX}" cy="${centerY}" r="4" fill="#1e293b"/>
+  
+  <!-- Title -->
+  <text x="${centerX}" y="30" text-anchor="middle" font-family="serif" font-size="16" font-weight="bold" fill="#1e293b">Katachi Gen</text>
+  <text x="${centerX}" y="${size-20}" text-anchor="middle" font-family="serif" font-size="12" fill="#64748b">形現</text>
+</svg>`;
+}
+
+export function generatePlaceholderPattern(data: PatternData): GeneratedPattern {
+  // Determine complexity based on NFT collection data
+  const complexity = data.nftCount > 20 ? 'High' : data.nftCount > 8 ? 'Medium' : 'Basic';
+  const complexityValue = complexity === 'High' ? 3 : complexity === 'Medium' ? 2 : 1;
+  
+  // Select colors based on collection diversity
+  const colorCount = Math.min(Math.max(data.collections, 2), 6);
+  const colors = BASE_COLORS.slice(0, colorCount);
+  
+  // Random pattern selection
+  const patternType = ORIGAMI_PATTERNS[Math.floor(Math.random() * ORIGAMI_PATTERNS.length)];
+  const foldLines = 12 + complexityValue * 6 + Math.floor(Math.random() * 8);
+  
+  // Generate SVG
+  const svgContent = generateRandomOrigamiSVG(colors, complexityValue);
+  
+  // Generate comprehensive metadata
+  const tokenId = Math.floor(Math.random() * 9999) + 1;
+  
+  return {
+    svgContent,
+    metadata: {
+      name: `Katachi Gen #${tokenId}`,
+      description: `A unique origami NFT generated from on-chain wallet activity on Shape Network. This ${patternType.toLowerCase()} pattern represents the holder's journey through ${data.collections} collections with ${data.nftCount} total NFTs, creating a ${complexity.toLowerCase()} complexity design with ${foldLines} fold lines.`,
+      patternType,
+      complexity,
+      foldLines,
+      colors,
+      traits: [
+        {
+          trait_type: 'Pattern Type',
+          value: patternType
+        },
+        {
+          trait_type: 'Complexity',
+          value: complexity
+        },
+        {
+          trait_type: 'Fold Lines',
+          value: foldLines
+        },
+        {
+          trait_type: 'NFT Count',
+          value: data.nftCount
+        },
+        {
+          trait_type: 'Collections',
+          value: data.collections
+        },
+        {
+          trait_type: 'Color Palette Size',
+          value: colors.length
+        },
+        {
+          trait_type: 'Generation',
+          value: 'Placeholder' // Will be changed to 'Algorithmic' later
+        },
+        {
+          trait_type: 'Network',
+          value: 'Shape'
+        },
+        {
+          trait_type: 'Chain ID',
+          value: 11011 // Shape Sepolia
+        },
+        {
+          trait_type: 'Created Via',
+          value: 'Katachi Gen App'
+        },
+        {
+          trait_type: 'Wallet Seed',
+          value: data.walletAddress.slice(0, 6) + '...' + data.walletAddress.slice(-4)
+        }
+      ]
+    }
+  };
+}


### PR DESCRIPTION
## Summary

🎯 **Complete NFT minting functionality** with dual-chain support and comprehensive safety measures.

### Key Features
- **Full minting pipeline**: Generate SVG patterns → Prepare transaction → Execute mint
- **Dual-chain architecture**: Read from mainnet (real data), mint to testnet (safe testing)
- **Rich metadata**: 11+ NFT traits including pattern type, complexity, wallet data
- **Safety protections**: Multiple layers to prevent accidental mainnet minting

### Technical Implementation
- New `/api/mint-origami` route with JSON-RPC MCP server integration
- Enhanced `KatachiGenerator` component with mint button and status tracking
- Custom `useMintOrigami` hook for transaction management
- Updated MCP server to use deployed KatachiGen contracts

### Configuration Changes
- Separate chain IDs: `NEXT_PUBLIC_READ_CHAIN_ID` (360) and `NEXT_PUBLIC_MINT_CHAIN_ID` (11011)
- Contract addresses for both networks
- Safety flag: `NEXT_PUBLIC_ALLOW_MAINNET_MINTING=false` (default)
- Removed legacy `NEXT_PUBLIC_CHAIN_ID`

### Contract Integration
- **Testnet**: `0x9FdB107c9AAE301F021e1F34BEB8Ca6F2324de85`
- **Mainnet**: `0x9fba90186403d1c5e3e1971536862cf4ebb0f766`
- Updated ABI for `safeMintWithURI` function
- Auto token ID generation

## Test Plan

✅ **Successfully tested end-to-end minting flow**
- Generated placeholder SVG with metadata
- Prepared transaction via MCP server
- Executed mint on Shape Sepolia testnet
- **Test NFT**: https://sepolia.shapescan.xyz/token/0x9FdB107c9AAE301F021e1F34BEB8Ca6F2324de85/instance/1756013955402

### Safety Verification
- [x] Mainnet minting disabled by default
- [x] API route blocks mainnet minting when disabled
- [x] UI shows safety warnings
- [x] Fallback to testnet when safety engaged

## Next Steps
This establishes the foundation for algorithmic origami generation. The SVG placeholder system can be replaced with actual computational origami patterns while maintaining the same metadata structure and minting pipeline.

🤖 Generated with [Claude Code](https://claude.ai/code)