### PR TITLE
Fix Railway Chrome dependency and enhance katachi-generator v2

### DIFF
--- a/katachi-generator/image/thumbnail.js
+++ b/katachi-generator/image/thumbnail.js
@@ -1,7 +1,7 @@
 // Thumbnail generation using Playwright
 const fs = require('fs');
 const path = require('path');
-const { chromium } = require('playwright-core');
+const { chromium } = require('playwright');
 const { templateHTML } = require('../config');
 
 /**
@@ -10,35 +10,10 @@ const { templateHTML } = require('../config');
 async function generateThumbnail(data) {
     let browser;
     try {
-        // Try to find Chrome/Chromium executable
-        const possiblePaths = [
-            '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-            '/Applications/Chromium.app/Contents/MacOS/Chromium',
-            '/usr/bin/google-chrome-stable',
-            '/usr/bin/google-chrome',
-            '/usr/bin/chromium-browser',
-            '/usr/bin/chromium',
-            '/snap/bin/chromium',
-            process.env.CHROME_EXECUTABLE_PATH
-        ].filter(Boolean);
+        console.log('🚀 Launching Chromium with Playwright');
 
-        let executablePath = null;
-        for (const chromePath of possiblePaths) {
-            if (fs.existsSync(chromePath)) {
-                executablePath = chromePath;
-                break;
-            }
-        }
-
-        if (!executablePath) {
-            throw new Error('Chrome/Chromium not found. Please install Chrome or set CHROME_EXECUTABLE_PATH environment variable.');
-        }
-
-        console.log('🚀 Using Chrome at:', executablePath);
-
-        // Launch browser
+        // Launch browser with built-in Chromium
         browser = await chromium.launch({
-            executablePath: executablePath,
             headless: true,
             args: [
                 '--no-sandbox',

--- a/katachi-generator/package.json
+++ b/katachi-generator/package.json
@@ -23,7 +23,7 @@
     "dotenv": "^17.2.1",
     "inliner": "^1.13.1",
     "mime-types": "^3.0.1",
-    "playwright-core": "^1.55.0",
+    "playwright": "^1.55.0",
     "puppeteer-core": "^24.17.0",
     "sharp": "^0.34.3"
   },


### PR DESCRIPTION
## Summary
• Fix Railway deployment Chrome/Chromium dependency by switching to playwright with bundled Chromium
• Enhance public site UI with improved sentiment analysis and visual design
• Refactor katachi-generator into modular architecture with deferred metadata upload
• Improve NFT sentiment analysis and content filtering

## Key Changes
• Replace `playwright-core` with `playwright` package to include bundled Chromium
• Remove complex Chrome path detection that was failing on Railway deployments
• Enhance public site with better sentiment analysis UI and pagination
• Clean up mint API routes to use consistent Arweave URLs
• Add public temp folder serving for NFT previews

## Test plan
- [x] Verify thumbnail generation works with new playwright setup
- [ ] Test Railway deployment for Chrome dependency resolution
- [ ] Validate NFT generation and metadata upload flow
- [ ] Confirm public site sentiment analysis functionality

🤖 Generated with [Claude Code](https://claude.ai/code)